### PR TITLE
merge to develop

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,8 @@ dependencies {
 
 	// spring batch
 	implementation 'org.springframework.boot:spring-boot-starter-batch'
+
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 }
 // QueryDSL setting ------------------------------------------------------------------------------------------------
 def generated = layout.buildDirectory.dir("generated/querydsl").get().asFile

--- a/src/main/java/com/damyo/alpha/api/auth/controller/AuthController.java
+++ b/src/main/java/com/damyo/alpha/api/auth/controller/AuthController.java
@@ -36,7 +36,6 @@ public class AuthController {
 
     private final AuthService authService;
     private final S3ImageService s3ImageService;
-    private final UserRepository userRepository;
 
     @PostMapping(value = "/signup", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
     @Operation(summary = "회원가입", description = "토큰을 반환한다.")

--- a/src/main/java/com/damyo/alpha/api/auth/controller/AuthController.java
+++ b/src/main/java/com/damyo/alpha/api/auth/controller/AuthController.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -28,6 +29,7 @@ import java.util.UUID;
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
 @RestController
+@Slf4j
 @Tag(name = "AuthController")
 public class AuthController {
 
@@ -69,7 +71,9 @@ public class AuthController {
             @PathVariable String provider) {
 
         Map<String, Object> userInfo = authService.getUserInfo(provider, token);
+        log.info(userInfo.toString());
         String providerId = authService.getAttributesId(provider, userInfo);
+        log.info(providerId);
         UUID id = authService.checkIsMember(providerId);
         String jwt = authService.generateToken(id);
         return ResponseEntity.ok().body(new TokenResponse(jwt));

--- a/src/main/java/com/damyo/alpha/api/auth/controller/dto/SignUpRequest.java
+++ b/src/main/java/com/damyo/alpha/api/auth/controller/dto/SignUpRequest.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.NotBlank;
 
 @Schema(description = "회원가입 시 요청으로 오는 DTO")
 public record SignUpRequest (
-        @Schema(description = "소셜 로그인 후 발급 받은 토큰", example = "waiting@gmail.com")
+        @Schema(description = "소셜 로그인 후 발급 받은 토큰", example = "이거 지우고 소셜에서 받은 토큰 복붙하기")
         @Email String token,
         @Schema(description = "소셜 로그인 인증 제공자 (google, naver, kakao)", example = "kakao")
         String provider,

--- a/src/main/java/com/damyo/alpha/api/auth/controller/dto/SignUpRequest.java
+++ b/src/main/java/com/damyo/alpha/api/auth/controller/dto/SignUpRequest.java
@@ -6,8 +6,10 @@ import jakarta.validation.constraints.NotBlank;
 
 @Schema(description = "회원가입 시 요청으로 오는 DTO")
 public record SignUpRequest (
-        @Schema(description = "소셜 로그인 후 인증서버에서 받아오는 이메일", example = "waiting@gmail.com")
-        @Email String email,
+        @Schema(description = "소셜 로그인 후 발급 받은 토큰", example = "waiting@gmail.com")
+        @Email String token,
+        @Schema(description = "소셜 로그인 인증 제공자 (google, naver, kakao)", example = "kakao")
+        String provider,
         @Schema(description = "사용자의 이름, 실명은 아니고 서비스에서 사용할 이름", example = "홍길동")
         @NotBlank String name,
         @Schema(description = "사용자의 성별", example = "남자")

--- a/src/main/java/com/damyo/alpha/api/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/damyo/alpha/api/auth/exception/AuthErrorCode.java
@@ -15,7 +15,8 @@ public enum AuthErrorCode implements ErrorCode {
     EXPIRED_TOKEN(UNAUTHORIZED, "A103", "이미 만료된 토큰입니다"),
     INVALID_TOKEN(UNAUTHORIZED, "A104", "토큰이 유효하지 않습니다"),
     INVALID_PROVIDER(BAD_REQUEST, "A105", "인증 제공자가 올바르지 않습니다."),
-    UNKNOWN_ERROR(BAD_REQUEST, "A106", "예상하지 못한 에러입니다.")
+    FAIL_GET_INFO(BAD_REQUEST, "A106", "OAuth 토큰이 잘못되었거나 만료되었습니다."),
+    UNKNOWN_ERROR(BAD_REQUEST, "A107", "예상하지 못한 에러입니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/damyo/alpha/api/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/damyo/alpha/api/auth/exception/AuthErrorCode.java
@@ -11,8 +11,8 @@ import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 @Getter
 @RequiredArgsConstructor
 public enum AuthErrorCode implements ErrorCode {
-    EMAIL_ALREADY_EXIST(NOT_FOUND, "A101","해당 이메일이 이미 존재합니다"),
-    EMAIL_NOT_FOUND(NOT_FOUND, "A102", "해당 이메일이 존재하지 않습니다"),
+    ACCOUNT_ALREADY_EXIST(NOT_FOUND, "A101","해당 계정이 이미 존재합니다"),
+    ACCOUNT_NOT_FOUND(NOT_FOUND, "A102", "해당 계정이 존재하지 않습니다"),
     EXPIRED_TOKEN(UNAUTHORIZED, "A103", "이미 만료된 토큰입니다"),
     INVALID_TOKEN(UNAUTHORIZED, "A104", "토큰이 유효하지 않습니다")
     ;

--- a/src/main/java/com/damyo/alpha/api/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/damyo/alpha/api/auth/exception/AuthErrorCode.java
@@ -5,8 +5,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
-import static org.springframework.http.HttpStatus.NOT_FOUND;
-import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+import static org.springframework.http.HttpStatus.*;
 
 @Getter
 @RequiredArgsConstructor
@@ -14,7 +13,9 @@ public enum AuthErrorCode implements ErrorCode {
     ACCOUNT_ALREADY_EXIST(NOT_FOUND, "A101","해당 계정이 이미 존재합니다"),
     ACCOUNT_NOT_FOUND(NOT_FOUND, "A102", "해당 계정이 존재하지 않습니다"),
     EXPIRED_TOKEN(UNAUTHORIZED, "A103", "이미 만료된 토큰입니다"),
-    INVALID_TOKEN(UNAUTHORIZED, "A104", "토큰이 유효하지 않습니다")
+    INVALID_TOKEN(UNAUTHORIZED, "A104", "토큰이 유효하지 않습니다"),
+    INVALID_PROVIDER(BAD_REQUEST, "A105", "인증 제공자가 올바르지 않습니다."),
+    UNKNOWN_ERROR(BAD_REQUEST, "A106", "예상하지 못한 에러입니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/damyo/alpha/api/auth/exception/TokenException.java
+++ b/src/main/java/com/damyo/alpha/api/auth/exception/TokenException.java
@@ -1,0 +1,9 @@
+package com.damyo.alpha.api.auth.exception;
+
+import io.jsonwebtoken.JwtException;
+
+public class TokenException extends JwtException {
+    public TokenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/damyo/alpha/api/auth/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/damyo/alpha/api/auth/jwt/JwtAuthenticationEntryPoint.java
@@ -20,9 +20,6 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
         AuthErrorCode errorCode = (AuthErrorCode) request.getAttribute("exception");
-        if (errorCode == null) {
-            return;
-        }
         if (errorCode.equals(EXPIRED_TOKEN)) {
             setResponse(response, EXPIRED_TOKEN);
         } else if (errorCode.equals(INVALID_TOKEN)) {

--- a/src/main/java/com/damyo/alpha/api/auth/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/damyo/alpha/api/auth/jwt/JwtAuthenticationEntryPoint.java
@@ -6,11 +6,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import net.minidev.json.JSONObject;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
-import org.springframework.web.servlet.HandlerExceptionResolver;
 
 import java.io.IOException;
 

--- a/src/main/java/com/damyo/alpha/api/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/damyo/alpha/api/auth/jwt/JwtAuthenticationFilter.java
@@ -20,6 +20,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import static com.damyo.alpha.api.auth.exception.AuthErrorCode.*;
 import static com.damyo.alpha.global.exception.error.CommonErrorCode.INTERNAL_SERVER_ERROR;
@@ -34,8 +35,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String token = jwtProvider.resolveToken(request);
         try {
-            String email = jwtProvider.validateTokenAndGetEmail(token);
-            Authentication authentication = jwtProvider.createAuthentication(email);
+            UUID id = jwtProvider.validateTokenAndGetId(token);
+            Authentication authentication = jwtProvider.createAuthentication(id);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         } catch (ExpiredJwtException e) {
             request.setAttribute("exception", new AuthException(EXPIRED_TOKEN));

--- a/src/main/java/com/damyo/alpha/api/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/damyo/alpha/api/auth/jwt/JwtProvider.java
@@ -1,8 +1,11 @@
 package com.damyo.alpha.api.auth.jwt;
 
+import com.damyo.alpha.api.auth.exception.AuthErrorCode;
+import com.damyo.alpha.api.auth.exception.TokenException;
 import com.damyo.alpha.api.auth.service.UserDetailServiceImpl;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SecurityException;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +30,7 @@ public class JwtProvider {
 
     @Value("${jwt.secret}")
     private String secret;
-    private static final int EXPIRED_DURATION = 24;
+    private static final int EXPIRED_DURATION = 24 * 365;
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String GRANT_TYPE = "Bearer ";
     private Key key;
@@ -39,7 +42,7 @@ public class JwtProvider {
         key = Keys.hmacShaKeyFor(secret.getBytes());
     }
 
-    public String generate(UUID id) {
+    public String generate(String id) {
         Claims claims = Jwts.claims();
         claims.put("id", id);
         return generateToken(claims);
@@ -72,13 +75,13 @@ public class JwtProvider {
         return null;
     }
 
-    public UUID validateTokenAndGetId(String token) {
+    public String validateTokenAndGetId(String token) {
         return Jwts.parserBuilder()
                 .setSigningKey(key)
                 .build()
                 .parseClaimsJws(token)
                 .getBody()
-                .get("id", UUID.class);
+                .get("id", String.class);
     }
 
     public Authentication createAuthentication(UUID id) {

--- a/src/main/java/com/damyo/alpha/api/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/damyo/alpha/api/auth/jwt/JwtProvider.java
@@ -18,6 +18,7 @@ import java.security.Key;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Date;
+import java.util.UUID;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -38,9 +39,9 @@ public class JwtProvider {
         key = Keys.hmacShaKeyFor(secret.getBytes());
     }
 
-    public String generate(String email) {
+    public String generate(UUID id) {
         Claims claims = Jwts.claims();
-        claims.put("email", email);
+        claims.put("id", id);
         return generateToken(claims);
     }
 
@@ -71,17 +72,17 @@ public class JwtProvider {
         return null;
     }
 
-    public String validateTokenAndGetEmail(String token) {
+    public UUID validateTokenAndGetId(String token) {
         return Jwts.parserBuilder()
                 .setSigningKey(key)
                 .build()
                 .parseClaimsJws(token)
                 .getBody()
-                .get("email", String.class);
+                .get("id", UUID.class);
     }
 
-    public Authentication createAuthentication(String email) {
-        UserDetails userDetails = userDetailService.loadUserByUsername(email);
+    public Authentication createAuthentication(UUID id) {
+        UserDetails userDetails = userDetailService.loadUserByUsername(id.toString());
         return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
     }
 }

--- a/src/main/java/com/damyo/alpha/api/auth/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/damyo/alpha/api/auth/jwt/filter/JwtAuthenticationFilter.java
@@ -19,6 +19,7 @@ import org.springframework.security.web.access.ExceptionTranslationFilter;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.servlet.mvc.support.DefaultHandlerExceptionResolver;
 
 import java.io.IOException;
 import java.util.UUID;
@@ -35,18 +36,18 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String token = jwtProvider.resolveToken(request);
-        if (StringUtils.hasText(token)) {
-            try {
-                String id = jwtProvider.validateTokenAndGetId(token);
-                Authentication authentication = jwtProvider.createAuthentication(UUID.fromString(id));
-                SecurityContextHolder.getContext().setAuthentication(authentication);
-            } catch (ExpiredJwtException e) {
-                request.setAttribute("exception", EXPIRED_TOKEN);
-            } catch (SecurityException | MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e) {
-                request.setAttribute("exception", INVALID_TOKEN);
-            } catch (Exception e) {
-                request.setAttribute("exception", UNKNOWN_ERROR);
-            }
+        log.info(request.getRequestURI());
+        try {
+            String id = jwtProvider.validateTokenAndGetId(token);
+            Authentication authentication = jwtProvider.createAuthentication(UUID.fromString(id));
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        } catch (ExpiredJwtException e) {
+            request.setAttribute("exception", EXPIRED_TOKEN);
+        } catch (SecurityException | MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e) {
+            log.info(e.getMessage());
+            request.setAttribute("exception", INVALID_TOKEN);
+        } catch (Exception e) {
+            request.setAttribute("exception", UNKNOWN_ERROR);
         }
         filterChain.doFilter(request, response);
     }

--- a/src/main/java/com/damyo/alpha/api/auth/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/damyo/alpha/api/auth/jwt/filter/JwtAuthenticationFilter.java
@@ -1,10 +1,11 @@
-package com.damyo.alpha.api.auth.jwt;
+package com.damyo.alpha.api.auth.jwt.filter;
 
 import com.damyo.alpha.api.auth.exception.AuthException;
+import com.damyo.alpha.api.auth.exception.TokenException;
+import com.damyo.alpha.api.auth.jwt.JwtProvider;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.security.SecurityException;
-import io.jsonwebtoken.security.SignatureException;
 import io.jsonwebtoken.UnsupportedJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -12,38 +13,41 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.web.access.ExceptionTranslationFilter;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.util.UUID;
 
 import static com.damyo.alpha.api.auth.exception.AuthErrorCode.*;
-import static com.damyo.alpha.global.exception.error.CommonErrorCode.INTERNAL_SERVER_ERROR;
+
 
 @RequiredArgsConstructor
-@Component
 @Slf4j
+@Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String token = jwtProvider.resolveToken(request);
-        try {
-            UUID id = jwtProvider.validateTokenAndGetId(token);
-            Authentication authentication = jwtProvider.createAuthentication(id);
-            SecurityContextHolder.getContext().setAuthentication(authentication);
-        } catch (ExpiredJwtException e) {
-            request.setAttribute("exception", new AuthException(EXPIRED_TOKEN));
-        } catch (SecurityException | MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e) {
-            request.setAttribute("exception", new AuthException(INVALID_TOKEN));
+        if (StringUtils.hasText(token)) {
+            try {
+                String id = jwtProvider.validateTokenAndGetId(token);
+                Authentication authentication = jwtProvider.createAuthentication(UUID.fromString(id));
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            } catch (ExpiredJwtException e) {
+                request.setAttribute("exception", EXPIRED_TOKEN);
+            } catch (SecurityException | MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e) {
+                request.setAttribute("exception", INVALID_TOKEN);
+            } catch (Exception e) {
+                request.setAttribute("exception", UNKNOWN_ERROR);
+            }
         }
-
         filterChain.doFilter(request, response);
     }
 }

--- a/src/main/java/com/damyo/alpha/api/auth/service/AuthService.java
+++ b/src/main/java/com/damyo/alpha/api/auth/service/AuthService.java
@@ -13,8 +13,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.oauth2.client.registration.ClientRegistration;
-import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestOperations;

--- a/src/main/java/com/damyo/alpha/api/auth/service/AuthService.java
+++ b/src/main/java/com/damyo/alpha/api/auth/service/AuthService.java
@@ -15,6 +15,7 @@ import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestOperations;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -109,8 +110,12 @@ public class AuthService {
         HttpHeaders headers = new HttpHeaders();
         headers.setBearerAuth(token);
         RequestEntity<?> request = new RequestEntity<>(headers, HttpMethod.GET, uri);
-        ResponseEntity<Map<String, Object>> exchange = restTemplate.exchange(request, PARAMETERIZED_RESPONSE_TYPE);
-        return exchange.getBody();
+        try {
+            ResponseEntity<Map<String, Object>> exchange = restTemplate.exchange(request, PARAMETERIZED_RESPONSE_TYPE);
+            return exchange.getBody();
+        } catch (HttpClientErrorException e) {
+            throw new AuthException(FAIL_GET_INFO);
+        }
     }
 
     public UUID checkIsMember(String providerId) {

--- a/src/main/java/com/damyo/alpha/api/auth/service/AuthService.java
+++ b/src/main/java/com/damyo/alpha/api/auth/service/AuthService.java
@@ -8,38 +8,104 @@ import com.damyo.alpha.api.auth.jwt.JwtProvider;
 import com.damyo.alpha.api.user.domain.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestOperations;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 
-import static com.damyo.alpha.api.auth.exception.AuthErrorCode.EMAIL_ALREADY_EXIST;
-import static com.damyo.alpha.api.auth.exception.AuthErrorCode.EMAIL_NOT_FOUND;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.UUID;
+
+import static com.damyo.alpha.api.auth.exception.AuthErrorCode.*;
 
 @RequiredArgsConstructor
 @Service
 @Slf4j
 public class AuthService {
+    private static final String GOOGLE_USER_INFO_URI = "https://www.googleapis.com/oauth2/v1/userinfo";
+    private static final String NAVER_USER_INFO_URI = "https://openapi.naver.com/v1/nid/me";
+    private static final String KAKAO_USER_INFO_URI = "https://kapi.kakao.com/v2/user/me";
+    private static final String PROVIDER_GOOGLE = "google";
+    private static final String PROVIDER_NAVER = "naver";
+    private static final String PROVIDER_KAKAO = "kakao";
+    private static final ParameterizedTypeReference<Map<String, Object>> PARAMETERIZED_RESPONSE_TYPE = new ParameterizedTypeReference<Map<String, Object>>() {
+    };
 
     private final UserRepository userRepository;
     private final JwtProvider jwtProvider;
 
-    public void signUp(SignUpRequest signUpRequest, String profileUrl) {
-        if (userRepository.findUserByEmail(signUpRequest.email()).isPresent()) {
-            throw new AuthException(EMAIL_ALREADY_EXIST);
+    public User signUp(SignUpRequest signUpRequest, String profileUrl) {
+        Map<String, Object> userInfo = getUserInfo(signUpRequest.provider(), signUpRequest.token());
+        String providerId = getAttributesId(signUpRequest.provider(), userInfo);
+        String email = getAttributesEmail(signUpRequest.provider(), userInfo);
+        if (userRepository.findUserByProviderId(providerId).isPresent()) {
+            throw new AuthException(ACCOUNT_ALREADY_EXIST);
         }
-        userRepository.save(new User(signUpRequest, profileUrl));
+        return userRepository.save(new User(signUpRequest, profileUrl, providerId, email));
     }
 
-    public User login(LoginRequest loginRequest) {
-        return userRepository.findUserByEmail(loginRequest.email())
-                .orElseThrow(() -> new AuthException(EMAIL_NOT_FOUND));
+    public Map<String, Object> getUserInfo(String provider, String providerToken) {
+        return loadUserAttributes(provider, providerToken);
     }
-    public User login(SignUpRequest signUpRequest) {
-        return userRepository.findUserByEmail(signUpRequest.email())
-                .orElseThrow(() -> new AuthException(EMAIL_NOT_FOUND));
+
+    public String getAttributesId(String provider, Map<String, Object> userAttributes) {
+        return switch (provider) {
+            case PROVIDER_GOOGLE -> (String) userAttributes.get("id");
+            case PROVIDER_NAVER -> null;
+            case PROVIDER_KAKAO -> null;
+            default -> null;
+        };
+    }
+
+    private String getAttributesEmail(String provider, Map<String, Object> userAttributes) {
+        return switch (provider) {
+            case PROVIDER_GOOGLE -> (String) userAttributes.get("email");
+            case PROVIDER_NAVER -> null;
+            case PROVIDER_KAKAO -> "kakao";
+            default -> null;
+        };
     }
 
     @Transactional
-    public String generateToken(User user) {
-        return jwtProvider.generate(user.getEmail());
+    public String generateToken(UUID id) {
+        return jwtProvider.generate(id);
+    }
+
+    private Map<String, Object> loadUserAttributes(String provider, String token) {
+        RestTemplate restTemplate = new RestTemplate();
+        String url = switch (provider) {
+            case PROVIDER_GOOGLE -> GOOGLE_USER_INFO_URI;
+            case PROVIDER_NAVER -> NAVER_USER_INFO_URI;
+            case PROVIDER_KAKAO -> KAKAO_USER_INFO_URI;
+            default ->
+                // 예외 처리 하기
+                    "null";
+        };
+        URI uri = UriComponentsBuilder
+                .fromUriString(url)
+                .build()
+                .toUri();
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token);
+        RequestEntity<?> request = new RequestEntity<>(headers, HttpMethod.GET, uri);
+        ResponseEntity<Map<String, Object>> exchange = restTemplate.exchange(request, PARAMETERIZED_RESPONSE_TYPE);
+        return exchange.getBody();
+    }
+
+    public UUID checkIsMember(String providerId) {
+        User user = userRepository.findUserByProviderId(providerId).orElseThrow(
+                () -> new AuthException(ACCOUNT_NOT_FOUND)
+        );
+        return user.getId();
     }
 }

--- a/src/main/java/com/damyo/alpha/api/auth/service/UserDetailServiceImpl.java
+++ b/src/main/java/com/damyo/alpha/api/auth/service/UserDetailServiceImpl.java
@@ -9,15 +9,17 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
+import java.util.UUID;
+
 @Service
 @RequiredArgsConstructor
 public class UserDetailServiceImpl implements UserDetailsService {
 
     private final UserRepository userRepository;
     @Override
-    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        User user = userRepository.findUserByEmail(email)
-                .orElseThrow(() -> new UsernameNotFoundException("not found email"));
+    public UserDetails loadUserByUsername(String id) throws UsernameNotFoundException {
+        User user = userRepository.findUserById(UUID.fromString(id))
+                .orElseThrow(() -> new UsernameNotFoundException("not found id"));
         return new UserDetailsImpl(user);
     }
 }

--- a/src/main/java/com/damyo/alpha/api/user/controller/dto/UserResponse.java
+++ b/src/main/java/com/damyo/alpha/api/user/controller/dto/UserResponse.java
@@ -25,11 +25,15 @@ public record UserResponse (
         @Schema(example = "34.2", description = "유저의 기여도 상위 백분위")
         float percentage,
         @Schema(example = "40", description = "기여도 1등과의 기여도 차이")
-        int gap
+        int gap,
+        @Schema(example = "kakao", description = "인증 제공자")
+        String provider,
+        @Schema(description = "인증 서버에서 제공하는 고유한 id값")
+        String providerId
 
 ) {
     public UserResponse(User user, float percentage, int gap) {
-        this(user.getId(), user.getName(), user.getEmail(), user.getCreatedAt(),
-                user.getProfileUrl(), user.getContribution(), user.getGender(), user.getAge(), percentage, gap);
+        this(user.getId(), user.getName(), user.getEmail(), user.getCreatedAt(), user.getProfileUrl(), user.getContribution(),
+                user.getGender(), user.getAge(), percentage, gap, user.getProvider(), user.getProviderId());
     }
 }

--- a/src/main/java/com/damyo/alpha/api/user/domain/User.java
+++ b/src/main/java/com/damyo/alpha/api/user/domain/User.java
@@ -34,6 +34,10 @@ public class User {
     private String name;
     @Column(name = "email")
     private String email;
+    @Column(name = "provider")
+    private String provider;
+    @Column(name = "provider_id")
+    private String providerId;
     @CreatedDate
     @Column(name = "created_at")
     private LocalDateTime createdAt;
@@ -58,8 +62,8 @@ public class User {
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
     private List<Info> infoList = new ArrayList<>();
 
-    public User(SignUpRequest signUpDto, String profileUrl) {
-        this(null, signUpDto.name(), signUpDto.email(), null, profileUrl, 0, signUpDto.gender(), signUpDto.age(),
-                new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
+    public User(SignUpRequest signUpDto, String profileUrl, String providerId, String email) {
+        this(null, signUpDto.name(), email, signUpDto.provider(), providerId, null, profileUrl, 0,
+                signUpDto.gender(), signUpDto.age(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
     }
 }

--- a/src/main/java/com/damyo/alpha/api/user/domain/UserRepository.java
+++ b/src/main/java/com/damyo/alpha/api/user/domain/UserRepository.java
@@ -40,4 +40,6 @@ public interface UserRepository extends JpaRepository<User, UUID> {
                    "order by contribution desc " +
                    "limit 1", nativeQuery = true)
     int getTop1Contribution();
+
+    Optional<User> findUserByProviderId(String providerId);
 }

--- a/src/main/java/com/damyo/alpha/global/config/SecurityConfig.java
+++ b/src/main/java/com/damyo/alpha/global/config/SecurityConfig.java
@@ -21,14 +21,13 @@ public class SecurityConfig {
     private final JwtAuthenticationEntryPoint entryPoint;
     private static final String[] ALLOWED_URLS = {
             "/api/auth/**", "/api/area/**", "/api/info/{saId}",
-            "/swagger-ui/**", "/v3/**", "/favicon.ico"
+            "/swagger-ui/**", "/v3/**", "/favicon.ico", "/error"
     };
 
     @Bean
     SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http.authorizeHttpRequests(authorizeRequest ->
-                authorizeRequest.requestMatchers(ALLOWED_URLS).permitAll()
-                        .anyRequest().authenticated())
+                authorizeRequest.requestMatchers(ALLOWED_URLS).permitAll())
                 .csrf(AbstractHttpConfigurer::disable)
                 .cors(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)

--- a/src/main/java/com/damyo/alpha/global/config/SecurityConfig.java
+++ b/src/main/java/com/damyo/alpha/global/config/SecurityConfig.java
@@ -1,9 +1,8 @@
 package com.damyo.alpha.global.config;
 
 import com.damyo.alpha.api.auth.jwt.JwtAuthenticationEntryPoint;
-import com.damyo.alpha.api.auth.jwt.JwtAuthenticationFilter;
+import com.damyo.alpha.api.auth.jwt.filter.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;

--- a/src/main/java/com/damyo/alpha/global/config/WebConfig.java
+++ b/src/main/java/com/damyo/alpha/global/config/WebConfig.java
@@ -1,6 +1,6 @@
 package com.damyo.alpha.global.config;
 
-import com.damyo.alpha.global.coverter.OctetStreamReadMsgConverter;
+import com.damyo.alpha.global.converter.OctetStreamReadMsgConverter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.converter.HttpMessageConverter;

--- a/src/main/java/com/damyo/alpha/global/converter/OctetStreamReadMsgConverter.java
+++ b/src/main/java/com/damyo/alpha/global/converter/OctetStreamReadMsgConverter.java
@@ -1,4 +1,4 @@
-package com.damyo.alpha.global.coverter;
+package com.damyo.alpha.global.converter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/com/damyo/alpha/global/exception/error/CommonErrorCode.java
+++ b/src/main/java/com/damyo/alpha/global/exception/error/CommonErrorCode.java
@@ -8,9 +8,9 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum CommonErrorCode implements ErrorCode {
 
-    INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "100","Invalid parameter included"),
-    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "100", "Resource not exists"),
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "100","Internal server error"),
+    INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "G101","Invalid parameter included"),
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "G102", "Resource not exists"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "G103","서버에 문제가 발생했습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/damyo/alpha/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/damyo/alpha/global/exception/handler/GlobalExceptionHandler.java
@@ -15,7 +15,7 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler
-    public ResponseEntity<ErrorResponse> handleUserException(BaseException e) {
+    public ResponseEntity<ErrorResponse> handleBaseException(BaseException e) {
         ErrorCode errorCode = e.getErrorCode();
         return ResponseEntity.status(errorCode.getHttpStatus()).body(new ErrorResponse(errorCode.getExceptionCode(), errorCode.getMessage()));
     }

--- a/src/main/java/com/damyo/alpha/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/damyo/alpha/global/exception/handler/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.damyo.alpha.global.exception.handler;
 
 import com.damyo.alpha.global.exception.error.BaseException;
+import com.damyo.alpha.global.exception.error.CommonErrorCode;
 import com.damyo.alpha.global.exception.error.ErrorCode;
 import com.damyo.alpha.api.auth.exception.AuthException;
 import com.damyo.alpha.global.exception.error.ErrorResponse;
@@ -17,6 +18,13 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     @ExceptionHandler
     public ResponseEntity<ErrorResponse> handleBaseException(BaseException e) {
         ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity.status(errorCode.getHttpStatus()).body(new ErrorResponse(errorCode.getExceptionCode(), errorCode.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleInternalException(Exception e) {
+        log.error(e.getClass() + " : " + e.getMessage());
+        ErrorCode errorCode = CommonErrorCode.INTERNAL_SERVER_ERROR;
         return ResponseEntity.status(errorCode.getHttpStatus()).body(new ErrorResponse(errorCode.getExceptionCode(), errorCode.getMessage()));
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -50,14 +50,3 @@ springdoc:
     persist-authorization: true
   paths-to-match:
     - /api/**
-
-provider:
-  google:
-    user_info_uri: https://www.googleapis.com/oauth2/v1/userinfo
-    method: get
-  naver:
-    user_info_uri: https://openapi.naver.com/v1/nid/me
-    method: get
-  kakao:
-    user_info_uri: https://kapi.kakao.com/v2/user/me
-    method: get

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -50,3 +50,14 @@ springdoc:
     persist-authorization: true
   paths-to-match:
     - /api/**
+
+provider:
+  google:
+    user_info_uri: https://www.googleapis.com/oauth2/v1/userinfo
+    method: get
+  naver:
+    user_info_uri: https://openapi.naver.com/v1/nid/me
+    method: get
+  kakao:
+    user_info_uri: https://kapi.kakao.com/v2/user/me
+    method: get


### PR DESCRIPTION
### 로그인 방식 변경
- 이메일로 토큰을 발급하는 방식에서 구글, 네이버, 카카오가 준 토큰으로 우리 토큰을 발급하는 방식으로 변경
- UUID생성 전, 기존 회원의 고유한 식별자를 email에서 각 인증서버에서 제공하는 "id"값(providerId)로 변경(카카오는 이메일이 없을 수 있는 등 변수가 많기 때문에). 따라서 기존 email컬럼의 역할을 providerId이 컬럼이 대체함
