### PR TITLE
Fix/#96 naver user info fetch

### DIFF
--- a/src/main/java/com/damyo/alpha/api/auth/controller/AuthController.java
+++ b/src/main/java/com/damyo/alpha/api/auth/controller/AuthController.java
@@ -68,9 +68,9 @@ public class AuthController {
     })
     public ResponseEntity<TokenResponse> login(
             @Parameter(description = "로그인 요청사항", in = ParameterIn.DEFAULT, required = true)
-            @RequestParam String token,
+            @RequestHeader("Authorization") String authorHeader,
             @PathVariable String provider) {
-        log.info("Oauth token: " + token);
+        String token = authorHeader.substring(7);
         Map<String, Object> userInfo = authService.getUserInfo(provider, token);
         String providerId = authService.getAttributesId(provider, userInfo);
         UUID id = authService.checkIsMember(providerId);

--- a/src/main/java/com/damyo/alpha/api/auth/controller/AuthController.java
+++ b/src/main/java/com/damyo/alpha/api/auth/controller/AuthController.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
@@ -37,29 +38,6 @@ public class AuthController {
     private final AuthService authService;
     private final S3ImageService s3ImageService;
 
-    @PostMapping(value = "/signup", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
-    @Operation(summary = "회원가입", description = "토큰을 반환한다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "회원가입에 성공함", content = @Content(schema = @Schema(implementation = TokenResponse.class))),
-            @ApiResponse(responseCode = "A101", description = "이미 가입된 계정이 존재할 때(providerId 중복)", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
-    })
-    public ResponseEntity<TokenResponse> signUp(
-            @Parameter(description = "프로필 사진", in = ParameterIn.DEFAULT)
-            @RequestPart(value = "image", required = false) MultipartFile image,
-            @Parameter(description = "회원가입 요청사항", in = ParameterIn.DEFAULT, required = true)
-            @RequestPart SignUpRequest signUpRequest) {
-
-        String profileUrl = null;
-        if (image != null) {
-            profileUrl = s3ImageService.upload(image);
-        }
-
-        User user = authService.signUp(signUpRequest, profileUrl);
-        String jwt = authService.generateToken(user.getId());
-        return ResponseEntity.ok().body(new TokenResponse(jwt));
-    }
-
-
     @PostMapping("/login/{provider}")
     @Operation(summary = "로그인", description = "토큰을 반환한다.")
     @ApiResponses(value = {
@@ -67,15 +45,11 @@ public class AuthController {
             @ApiResponse(responseCode = "A102", description = "해당 토큰으로 받아온 providerId DB에 존재하지 않을 때.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     public ResponseEntity<TokenResponse> login(
-            @Parameter(description = "헤더에 위치한 인증 제공자에게 받은 토큰, 토큰 타입은 bearer", in = ParameterIn.DEFAULT, required = true)
-            @RequestHeader("Authorization") String authorHeader,
+            @RequestHeader(value = "Authorization", required = false) String authorHeader,
             @Parameter(description = "토큰을 제공한 인증 제공자(google, naver, kakao)", in = ParameterIn.DEFAULT, required = true)
             @PathVariable String provider) {
         String token = authorHeader.substring(7);
-        Map<String, Object> userInfo = authService.getUserInfo(provider, token);
-        String providerId = authService.getAttributesId(provider, userInfo);
-        UUID id = authService.checkIsMember(providerId);
-        String jwt = authService.generateToken(id);
+        String jwt = authService.login(token, provider);
         return ResponseEntity.ok().body(new TokenResponse(jwt));
     }
 
@@ -83,8 +57,7 @@ public class AuthController {
     @Operation(summary = "소셜 로그인 생략하고 토큰 발급받기(테스트용)", description = "바뀐 로그인 방식으로 회원가입된 3개의 계정에 대해 토큰을 발급받는다." +
             "'106362899132468449802', '3399007981', 'tmO5sDw_IaLlon7-M7CesK43rgFDdAnogEKq-ubl_9c' 중에 하나를 골라 providerId에 넣는다")
     public ResponseEntity<TokenResponse> getToken(@RequestParam String providerId) {
-        UUID id = authService.checkIsMember(providerId);
-        String jwt = authService.generateToken(id);
+        String jwt = authService.generateTestToken(providerId);
         return ResponseEntity.ok().body(new TokenResponse(jwt));
     }
 }

--- a/src/main/java/com/damyo/alpha/api/auth/controller/AuthController.java
+++ b/src/main/java/com/damyo/alpha/api/auth/controller/AuthController.java
@@ -67,8 +67,9 @@ public class AuthController {
             @ApiResponse(responseCode = "A102", description = "해당 토큰으로 받아온 providerId DB에 존재하지 않을 때.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     public ResponseEntity<TokenResponse> login(
-            @Parameter(description = "로그인 요청사항", in = ParameterIn.DEFAULT, required = true)
+            @Parameter(description = "헤더에 위치한 인증 제공자에게 받은 토큰, 토큰 타입은 bearer", in = ParameterIn.DEFAULT, required = true)
             @RequestHeader("Authorization") String authorHeader,
+            @Parameter(description = "토큰을 제공한 인증 제공자(google, naver, kakao)", in = ParameterIn.DEFAULT, required = true)
             @PathVariable String provider) {
         String token = authorHeader.substring(7);
         Map<String, Object> userInfo = authService.getUserInfo(provider, token);

--- a/src/main/java/com/damyo/alpha/api/auth/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/damyo/alpha/api/auth/jwt/filter/JwtAuthenticationFilter.java
@@ -44,7 +44,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         } catch (ExpiredJwtException e) {
             request.setAttribute("exception", EXPIRED_TOKEN);
         } catch (SecurityException | MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e) {
-            log.info(e.getMessage());
             request.setAttribute("exception", INVALID_TOKEN);
         } catch (Exception e) {
             request.setAttribute("exception", UNKNOWN_ERROR);

--- a/src/main/java/com/damyo/alpha/api/auth/service/AuthService.java
+++ b/src/main/java/com/damyo/alpha/api/auth/service/AuthService.java
@@ -12,6 +12,8 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestOperations;
 import org.springframework.web.client.RestTemplate;
@@ -19,6 +21,9 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Map;
 import java.util.UUID;
 
@@ -100,13 +105,17 @@ public class AuthService {
             case PROVIDER_KAKAO -> KAKAO_USER_INFO_URI;
             default -> throw new AuthException(INVALID_PROVIDER);
         };
+
         URI uri = UriComponentsBuilder
                 .fromUriString(url)
                 .build()
                 .toUri();
+
         HttpHeaders headers = new HttpHeaders();
-        headers.setBearerAuth(token);
+        headers.add("Content-type", "application/x-www-form-urlencoded:utf-8");
+        headers.add("Authorization", "Bearer " + token);
         RequestEntity<?> request = new RequestEntity<>(headers, HttpMethod.GET, uri);
+
         try {
             ResponseEntity<Map<String, Object>> exchange = restTemplate.exchange(request, PARAMETERIZED_RESPONSE_TYPE);
             return exchange.getBody();

--- a/src/main/java/com/damyo/alpha/api/auth/service/AuthService.java
+++ b/src/main/java/com/damyo/alpha/api/auth/service/AuthService.java
@@ -52,7 +52,7 @@ public class AuthService {
     public String login(String token, String provider) {
         Map<String, Object> userInfo = getUserInfo(token, provider);
         String providerId = getAttributesId(userInfo, provider);
-        User user = findOrCreateUser(providerId, provider);
+        User user = findOrCreateUser(provider, providerId);
         return jwtProvider.generate(user.getId().toString());
     }
 

--- a/src/main/java/com/damyo/alpha/api/user/domain/User.java
+++ b/src/main/java/com/damyo/alpha/api/user/domain/User.java
@@ -62,8 +62,8 @@ public class User {
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
     private List<Info> infoList = new ArrayList<>();
 
-    public User(SignUpRequest signUpDto, String profileUrl, String providerId, String email) {
-        this(null, signUpDto.name(), email, signUpDto.provider(), providerId, null, profileUrl, 0,
-                signUpDto.gender(), signUpDto.age(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
+    public User(String name, String provider, String providerId, String profileUrl) {
+        this(null, name, null, provider, providerId, null, profileUrl, 0,
+                null, 0, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
     }
 }

--- a/src/main/java/com/damyo/alpha/global/config/SwaggerConfig.java
+++ b/src/main/java/com/damyo/alpha/global/config/SwaggerConfig.java
@@ -14,17 +14,22 @@ public class SwaggerConfig {
     @Bean
     public OpenAPI openAPI() {
         String jwt = "jwt";
-        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwt);
-        Components components = new Components().addSecuritySchemes(
-                jwt, new SecurityScheme().name(jwt).type(SecurityScheme.Type.HTTP)
+        String providerToken = "providerToken";
+        SecurityRequirement jwtSecurityRequirement = new SecurityRequirement().addList(jwt);
+        SecurityRequirement providerTokenSecurityRequirement = new SecurityRequirement().addList(providerToken);
+        Components components = new Components()
+                .addSecuritySchemes(jwt, new SecurityScheme().name(jwt).type(SecurityScheme.Type.HTTP)
                         .scheme("bearer")
-                        .bearerFormat("JWT")
-        );
+                        .bearerFormat("JWT"))
+                .addSecuritySchemes(providerToken, new SecurityScheme().name(providerToken).type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .bearerFormat("token"));
 
         return new OpenAPI()
                 .components(new Components())
                 .info(apiInfo())
-                .addSecurityItem(securityRequirement)
+                .addSecurityItem(jwtSecurityRequirement)
+                .addSecurityItem(providerTokenSecurityRequirement)
                 .components(components);
     }
 


### PR DESCRIPTION
## Overview
- 네이버 로그인 오류 해결
- 처음 로그인 시 서버에서 바로 회원가입 후 토큰 발급하는 방식으로 변경

### Related Issue
Issue Number : #96

## Task Details
- 네이버 접근 토큰을 쿼리 파라미터로 받았을 때 '+'가 공백으로 바뀌어 문제를 일으켰고, 따라서 접근토큰을 헤더로 받는 것으로 변경
- 로그인 시 providerId가 테이블에 없는 경우 해당 유저를 저장하고 바로 토큰을 발급하는 방식으로 변경
- 불필요 코드 삭제와 코드 구조 개선
- 소셜 로그인 테스트를 위한 스웨거 헤더 설정 추가
## Screenshots (Optional)

![image](https://github.com/user-attachments/assets/7d9206e1-7123-4d7d-902a-47cbde490756)
- 아래꺼가 소셜 토큰 넣는 곳(api안에서의 파라미터는 비워놔도됨)

## Test Scope & Checklist (Optional)

## Review Requirements
