### PR TITLE
Feature/#118 Redis를 활용한 흡연구역 / 사진 정보 캐싱 + #120 리뷰 별점이 흡연구역 별점에 반영 안되는 버그 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,9 @@ dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+	// redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 
 	// jwt
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/src/main/java/com/damyo/alpha/AlphaApplication.java
+++ b/src/main/java/com/damyo/alpha/AlphaApplication.java
@@ -3,9 +3,11 @@ package com.damyo.alpha;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableCaching
 @EnableJpaAuditing
 @EnableScheduling
 @EnableBatchProcessing

--- a/src/main/java/com/damyo/alpha/api/info/service/InfoService.java
+++ b/src/main/java/com/damyo/alpha/api/info/service/InfoService.java
@@ -13,6 +13,7 @@ import com.damyo.alpha.api.user.domain.User;
 import com.damyo.alpha.api.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
@@ -32,7 +33,7 @@ public class InfoService {
 
     private static final int POST_INFO_CONTRIBUTION_INCREMENT = 5;
 
-    @CachePut(value="areaCache", key="#updateInfoRequest.smokingAreaId()", cacheManager="contentCacheManager")
+    @CacheEvict(value="areaCache", key="#updateInfoRequest.smokingAreaId()", cacheManager="contentCacheManager")
     public void updateInfo(UpdateInfoRequest updateInfoRequest, UserDetailsImpl details) {
         SmokingArea sa = smokingAreaRepository.findSmokingAreaById(updateInfoRequest.smokingAreaId())
                 .orElseThrow(() -> {

--- a/src/main/java/com/damyo/alpha/api/info/service/InfoService.java
+++ b/src/main/java/com/damyo/alpha/api/info/service/InfoService.java
@@ -43,6 +43,7 @@ public class InfoService {
         User user = details.getUser();
         infoRepository.save(updateInfoRequest.toEntity(sa, user));
         int size = infoRepository.findInfosBySmokingAreaId(updateInfoRequest.smokingAreaId()).size();
+        log.info("[test]: {}", size);
         Float score = (sa.getScore() * size + updateInfoRequest.score()) / (size + 1);
         smokingAreaRepository.updateSmokingAreaScoreById(score, sa.getId());
         userService.updateContribution(user.getId(), POST_INFO_CONTRIBUTION_INCREMENT);

--- a/src/main/java/com/damyo/alpha/api/info/service/InfoService.java
+++ b/src/main/java/com/damyo/alpha/api/info/service/InfoService.java
@@ -33,7 +33,7 @@ public class InfoService {
 
     private static final int POST_INFO_CONTRIBUTION_INCREMENT = 5;
 
-    @CacheEvict(value="areaCache", key="#updateInfoRequest.smokingAreaId()", cacheManager="contentCacheManager")
+    @CacheEvict(value={"areaDetailsCache", "areaSummaryCache"}, key="#updateInfoRequest.smokingAreaId()", cacheManager="contentCacheManager")
     public void updateInfo(UpdateInfoRequest updateInfoRequest, UserDetailsImpl details) {
         SmokingArea sa = smokingAreaRepository.findSmokingAreaById(updateInfoRequest.smokingAreaId())
                 .orElseThrow(() -> {

--- a/src/main/java/com/damyo/alpha/api/picture/controller/dto/PictureResponse.java
+++ b/src/main/java/com/damyo/alpha/api/picture/controller/dto/PictureResponse.java
@@ -1,11 +1,17 @@
 package com.damyo.alpha.api.picture.controller.dto;
 
 import com.damyo.alpha.api.picture.domain.Picture;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 
 import java.time.LocalDateTime;
 public record PictureResponse (
         Long id,
         String pictureUrl,
+        @JsonSerialize(using = LocalDateTimeSerializer.class)
+        @JsonDeserialize(using = LocalDateTimeDeserializer.class)
         LocalDateTime createdAt,
         Long likes
 ) {

--- a/src/main/java/com/damyo/alpha/api/picture/service/PictureService.java
+++ b/src/main/java/com/damyo/alpha/api/picture/service/PictureService.java
@@ -14,6 +14,7 @@ import com.damyo.alpha.api.user.exception.UserException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.redis.core.HashOperations;
@@ -43,6 +44,7 @@ public class PictureService {
     @Autowired
     private RedisTemplate<String, Object> countTemplate;
 
+    @Cacheable(value="pictureCache", key="#id", cacheManager="contentCacheManager")
     public PictureResponse getPicture(Long id) {
         Picture picture = pictureRepository.findPictureById(id)
             .orElseThrow(() -> {

--- a/src/main/java/com/damyo/alpha/api/picture/service/PictureService.java
+++ b/src/main/java/com/damyo/alpha/api/picture/service/PictureService.java
@@ -55,12 +55,14 @@ public class PictureService {
         return new PictureResponse(picture);
     }
 
+    @Cacheable(value="pictureUserCache", key="#id", cacheManager="contentCacheManager")
     public List<PictureResponse> getPicturesByUser(UUID id) {
         List<Picture> pictures = pictureRepository.findPicturesByUser_id(id);
         log.info("[Picture]: load pictures by user | {}", id);
         return getPictureListResponse(pictures);
     }
 
+    @Cacheable(value="pictureAreaCache", key="#id", cacheManager="contentCacheManager")
     public List<PictureResponse> getPicturesBySmokingArea(String id, Long count) {
         List<Picture> pictures = pictureRepository.findPicturesBySmokingArea_Id(id, count);
         log.info("[Picture]: load pictures by area | {}", id);

--- a/src/main/java/com/damyo/alpha/api/smokingarea/controller/SmokingAreaController.java
+++ b/src/main/java/com/damyo/alpha/api/smokingarea/controller/SmokingAreaController.java
@@ -46,7 +46,6 @@ public class SmokingAreaController {
     private final SmokingAreaService smokingAreaService;
     private final PictureService pictureService;
     private final UserService userService;
-    private final InfoService infoService;
     private final S3ImageService s3ImageService;
     private final RedisTemplate<String, Object> redisTemplate;
 
@@ -108,13 +107,11 @@ public class SmokingAreaController {
             @Parameter(description = "흡연구역 ID", in = ParameterIn.PATH)
             @PathVariable String smokingAreaId){
         log.info("[Area]: /details/{}", smokingAreaId);
-        SmokingAreaDetailResponse area = smokingAreaService.findAreaById(smokingAreaId).toDTO();
-        InfoResponse info = infoService.getInfo(smokingAreaId);
-        Float avgScore = Math.round((info.score() + area.score()) / (info.size()+1) * 10) / 10.0F;
+        SmokingAreaDetailResponse area = smokingAreaService.findAreaDTOById(smokingAreaId);
         List<PictureResponse> picList = pictureService.getPicturesBySmokingArea(smokingAreaId, 10L);
 
         SmokingAreaAllResponse response = new SmokingAreaAllResponse(area.areaId(), area.name(), area.latitude(), area.longitude(), area.address(),
-                area.createdAt(), area.description(), avgScore, area.status(), area.opened(), area.closed(),
+                area.createdAt(), area.description(), area.score(), area.status(), area.opened(), area.closed(),
                 area.indoor(), area.outdoor(), picList);
 
         return ResponseEntity.ok(response);
@@ -129,9 +126,9 @@ public class SmokingAreaController {
             @Parameter(description = "흡연구역 ID", in = ParameterIn.PATH)
             @PathVariable String smokingAreaId){
         log.info("[Area]: /summary/{}", smokingAreaId);
-        SmokingArea areaResponse = smokingAreaService.findAreaById(smokingAreaId);
+        SmokingAreaSummaryResponse response = smokingAreaService.findAreaSUMById(smokingAreaId);
 
-        return ResponseEntity.ok(areaResponse.toSUM());
+        return ResponseEntity.ok(response);
     }
 
     // 특정날짜이후 추가된 구역찾기

--- a/src/main/java/com/damyo/alpha/api/smokingarea/controller/SmokingAreaController.java
+++ b/src/main/java/com/damyo/alpha/api/smokingarea/controller/SmokingAreaController.java
@@ -107,6 +107,7 @@ public class SmokingAreaController {
             @Parameter(description = "흡연구역 ID", in = ParameterIn.PATH)
             @PathVariable String smokingAreaId){
         log.info("[Area]: /details/{}", smokingAreaId);
+
         SmokingAreaDetailResponse area = smokingAreaService.findAreaDTOById(smokingAreaId);
         List<PictureResponse> picList = pictureService.getPicturesBySmokingArea(smokingAreaId, 10L);
 

--- a/src/main/java/com/damyo/alpha/api/smokingarea/controller/dto/SmokingAreaDetailResponse.java
+++ b/src/main/java/com/damyo/alpha/api/smokingarea/controller/dto/SmokingAreaDetailResponse.java
@@ -1,5 +1,10 @@
 package com.damyo.alpha.api.smokingarea.controller.dto;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
@@ -9,6 +14,8 @@ public record SmokingAreaDetailResponse(
         BigDecimal latitude,
         BigDecimal longitude,
         String address,
+        @JsonSerialize(using = LocalDateTimeSerializer.class)
+        @JsonDeserialize(using = LocalDateTimeDeserializer.class)
         LocalDateTime createdAt,
         Boolean status,
         String description,

--- a/src/main/java/com/damyo/alpha/api/smokingarea/domain/SmokingAreaRepository.java
+++ b/src/main/java/com/damyo/alpha/api/smokingarea/domain/SmokingAreaRepository.java
@@ -53,6 +53,7 @@ public interface SmokingAreaRepository extends JpaRepository<SmokingArea, String
             "WHERE sa.id = :id")
     void updateSmokingAreaAddressById(@Param("address") String address, @Param("id") String id);
 
+    @Transactional
     @Modifying(clearAutomatically = true)
     @Query("UPDATE SmokingArea sa SET sa.score = :score " +
             "WHERE sa.id = :id")

--- a/src/main/java/com/damyo/alpha/api/smokingarea/domain/SmokingAreaRepository.java
+++ b/src/main/java/com/damyo/alpha/api/smokingarea/domain/SmokingAreaRepository.java
@@ -54,6 +54,11 @@ public interface SmokingAreaRepository extends JpaRepository<SmokingArea, String
     void updateSmokingAreaAddressById(@Param("address") String address, @Param("id") String id);
 
     @Modifying(clearAutomatically = true)
+    @Query("UPDATE SmokingArea sa SET sa.score = :score " +
+            "WHERE sa.id = :id")
+    void updateSmokingAreaScoreById(@Param("score") Float score, @Param("id") String id);
+
+    @Modifying(clearAutomatically = true)
     @Query("UPDATE SmokingArea sa SET sa.description = :description " +
             "WHERE sa.id = :id")
     void updateSmokingAreaDescriptionById(@Param("description") String description, @Param("id") String id);

--- a/src/main/java/com/damyo/alpha/api/smokingarea/service/SmokingAreaService.java
+++ b/src/main/java/com/damyo/alpha/api/smokingarea/service/SmokingAreaService.java
@@ -6,6 +6,7 @@ import com.damyo.alpha.api.smokingarea.domain.SmokingAreaRepository;
 import com.damyo.alpha.api.smokingarea.exception.AreaException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.SetOperations;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -37,6 +38,7 @@ public class SmokingAreaService {
         return areaResponses;
     }
 
+    @Cacheable(value="areaCache", key="#smokingAreaId", cacheManager="contentCacheManager")
     public SmokingArea findAreaById(String smokingAreaId) {
         SmokingArea area =  smokingAreaRepository.findSmokingAreaById(smokingAreaId)
                 .orElseThrow(() -> {

--- a/src/main/java/com/damyo/alpha/api/smokingarea/service/SmokingAreaService.java
+++ b/src/main/java/com/damyo/alpha/api/smokingarea/service/SmokingAreaService.java
@@ -38,14 +38,24 @@ public class SmokingAreaService {
         return areaResponses;
     }
 
-    @Cacheable(value="areaCache", key="#smokingAreaId", cacheManager="contentCacheManager")
-    public SmokingArea findAreaById(String smokingAreaId) {
+    @Cacheable(value="areaDetailsCache", key="#smokingAreaId", cacheManager="contentCacheManager")
+    public SmokingAreaDetailResponse findAreaDTOById(String smokingAreaId) {
         SmokingArea area =  smokingAreaRepository.findSmokingAreaById(smokingAreaId)
                 .orElseThrow(() -> {
-                    log.error("[Area]: area not found by id | {}", smokingAreaId);
+                    log.error("[Area]: area detail not found by id | {}", smokingAreaId);
                     return new AreaException(NOT_FOUND_ID);
                 });
-        return area;
+        return area.toDTO();
+    }
+
+    @Cacheable(value="areaSummaryCache", key="#smokingAreaId", cacheManager="contentCacheManager")
+    public SmokingAreaSummaryResponse findAreaSUMById(String smokingAreaId) {
+        SmokingArea area =  smokingAreaRepository.findSmokingAreaById(smokingAreaId)
+                .orElseThrow(() -> {
+                    log.error("[Area]: area summary not found by id | {}", smokingAreaId);
+                    return new AreaException(NOT_FOUND_ID);
+                });
+        return area.toSUM();
     }
 
     public List<SmokingAreaSummaryResponse> findAreaByCreatedAt(LocalDateTime createdAt) {

--- a/src/main/java/com/damyo/alpha/api/smokingdata/service/SmokingDataService.java
+++ b/src/main/java/com/damyo/alpha/api/smokingdata/service/SmokingDataService.java
@@ -9,6 +9,7 @@ import com.damyo.alpha.api.user.domain.User;
 import com.damyo.alpha.api.user.domain.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -23,6 +24,7 @@ public class SmokingDataService {
     private final SmokingAreaRepository smokingAreaRepository;
     private final UserRepository userRepository;
 
+    @Cacheable(value="areaCache", key="#areaId", cacheManager="contentCacheManager")
     public void addSmokingData(UUID userId, String areaId) {
         SmokingArea area = smokingAreaRepository.findSmokingAreaById(areaId).get();
         User user = userRepository.findUserById(userId).get();

--- a/src/main/java/com/damyo/alpha/api/smokingdata/service/SmokingDataService.java
+++ b/src/main/java/com/damyo/alpha/api/smokingdata/service/SmokingDataService.java
@@ -24,7 +24,6 @@ public class SmokingDataService {
     private final SmokingAreaRepository smokingAreaRepository;
     private final UserRepository userRepository;
 
-    @Cacheable(value="areaCache", key="#areaId", cacheManager="contentCacheManager")
     public void addSmokingData(UUID userId, String areaId) {
         SmokingArea area = smokingAreaRepository.findSmokingAreaById(areaId).get();
         User user = userRepository.findUserById(userId).get();

--- a/src/main/java/com/damyo/alpha/api/star/service/StarService.java
+++ b/src/main/java/com/damyo/alpha/api/star/service/StarService.java
@@ -13,6 +13,7 @@ import com.damyo.alpha.api.star.domain.StarRepository;
 import com.damyo.alpha.api.user.domain.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -30,6 +31,7 @@ public class StarService {
     private final StarRepository starRepository;
     private final SmokingAreaRepository smokingAreaRepository;
 
+    @Cacheable(value="areaCache", key="#request.saId()", cacheManager="contentCacheManager")
     public void addStar(AddStarRequest request, UserDetailsImpl details) {
         // 예외 처리 해야함
         SmokingArea smokingArea = smokingAreaRepository.findSmokingAreaById(request.saId()).get();

--- a/src/main/java/com/damyo/alpha/api/star/service/StarService.java
+++ b/src/main/java/com/damyo/alpha/api/star/service/StarService.java
@@ -31,7 +31,6 @@ public class StarService {
     private final StarRepository starRepository;
     private final SmokingAreaRepository smokingAreaRepository;
 
-    @Cacheable(value="areaCache", key="#request.saId()", cacheManager="contentCacheManager")
     public void addStar(AddStarRequest request, UserDetailsImpl details) {
         // 예외 처리 해야함
         SmokingArea smokingArea = smokingAreaRepository.findSmokingAreaById(request.saId()).get();

--- a/src/main/java/com/damyo/alpha/global/config/RedisCacheConfig.java
+++ b/src/main/java/com/damyo/alpha/global/config/RedisCacheConfig.java
@@ -1,0 +1,28 @@
+package com.damyo.alpha.global.config;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+@EnableCaching
+public class RedisCacheConfig {
+    @Bean
+    public CacheManager contentCacheManager(RedisConnectionFactory rcf) {
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
+                .entryTtl(Duration.ofMinutes(30L));
+
+        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(rcf).cacheDefaults(redisCacheConfiguration).build();
+    }
+}


### PR DESCRIPTION
## Overview

Redis를 사용해 흡연구역 정보와 사진 정보를 캐싱하여 조회시 성능을 크게 개선하였습니다.
또한 이전에 리뷰시 별점이 흡연구역의 별점에 반영되지 않는 버그를 수정하였습니다.

### Related Issue

Issue Number : #118, #120

## Task Details

흡연구역 요약정보 캐싱 -> Value : areaSummaryCache | Key : 흡연구역 ID
흡연구역 상세정보 캐싱 -> Value : areaSummaryCache | Key : 흡연구역 ID
사진 정보 캐싱 -> Value : pictureCache | Key : 사진ID
유저별 사진 정보 캐싱 -> Value : pcitureUserCache | Key : 유저 ID
흡연구역별 사진 정보 캐싱 -> Value : pictureAreaCache | Key : 흡연구역 ID
