### PR TITLE
Feature/#101 smoking area report

### DIFF
--- a/src/main/java/com/damyo/alpha/api/smokingarea/domain/SmokingArea.java
+++ b/src/main/java/com/damyo/alpha/api/smokingarea/domain/SmokingArea.java
@@ -67,6 +67,21 @@ public class SmokingArea {
     @Column(name = "is_active")
     private Boolean isActive;
 
+    @Column(name = "not_exist")
+    private Long notExist;
+
+    @Column(name = "incorrect_tag")
+    private Long incorrectTag;
+
+    @Column(name = "incorrect_locate")
+    private Long incorrectLocate;
+
+    @Column(name = "inappropriate_word")
+    private Long inappropriateWord;
+
+    @Column(name = "inappropriate_picture")
+    private Long inappropriatePicture;
+
     @Builder.Default
     @OneToMany(mappedBy = "smokingArea", fetch = FetchType.LAZY)
     @ToString.Exclude

--- a/src/main/java/com/damyo/alpha/api/smokingarea/domain/SmokingAreaReportDetail.java
+++ b/src/main/java/com/damyo/alpha/api/smokingarea/domain/SmokingAreaReportDetail.java
@@ -1,0 +1,25 @@
+package com.damyo.alpha.api.smokingarea.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class SmokingAreaReportDetail {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "other_suggestion", length = 500)
+    private String otherSuggestion;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "smoking_area_id")
+    private SmokingArea smokingArea;
+
+}
+

--- a/src/main/java/com/damyo/alpha/api/smokingarea/domain/SmokingAreaReportDetail.java
+++ b/src/main/java/com/damyo/alpha/api/smokingarea/domain/SmokingAreaReportDetail.java
@@ -17,9 +17,8 @@ public class SmokingAreaReportDetail {
     @Column(name = "other_suggestion", length = 500)
     private String otherSuggestion;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "smoking_area_id")
-    private SmokingArea smokingArea;
+    @Column(name = "smoking_area_id")
+    private String smokingAreaId;
 
 }
 

--- a/src/main/java/com/damyo/alpha/api/smokingarea/domain/SmokingAreaReportDetailRepository.java
+++ b/src/main/java/com/damyo/alpha/api/smokingarea/domain/SmokingAreaReportDetailRepository.java
@@ -1,0 +1,6 @@
+package com.damyo.alpha.api.smokingarea.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SmokingAreaReportDetailRepository extends JpaRepository<SmokingAreaReportDetail, Long> {
+}

--- a/src/main/java/com/damyo/alpha/api/smokingarea/domain/SmokingAreaRepository.java
+++ b/src/main/java/com/damyo/alpha/api/smokingarea/domain/SmokingAreaRepository.java
@@ -88,4 +88,34 @@ public interface SmokingAreaRepository extends JpaRepository<SmokingArea, String
     @Query("SELECT sa FROM SmokingArea sa " +
             "WHERE sa.id LIKE %:region%")
     List<SmokingArea> findSmokingAreaByRegion(@Param("region") String region);
+
+    @Transactional
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE SmokingArea sa SET sa.notExist = :notExist " +
+            "WHERE sa.id = :id")
+    void updateNotExist(@Param("id") String id, @Param("notExist") long notExist);
+
+    @Transactional
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE SmokingArea sa SET sa.incorrectTag = :incorrectTag " +
+            "WHERE sa.id = :id")
+    void updateIncorrectTag(@Param("id") String id, @Param("incorrectTag") long incorrectTag);
+
+    @Transactional
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE SmokingArea sa SET sa.incorrectLocate = :incorrectLocate " +
+            "WHERE sa.id = :id")
+    void updateIncorrectLocate(@Param("id") String id, @Param("incorrectLocate") long incorrectLocate);
+
+    @Transactional
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE SmokingArea sa SET sa.inappropriateWord = :inappropriateWord " +
+            "WHERE sa.id = :id")
+    void updateInappropriateWord(@Param("id") String id, @Param("inappropriateWord") long inappropriateWord);
+
+    @Transactional
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE SmokingArea sa SET sa.inappropriatePicture = :inappropriatePicture " +
+            "WHERE sa.id = :id")
+    void updateInappropriatePicture(@Param("id") String id, @Param("inappropriatePicture") long inappropriatePicture);
 }

--- a/src/main/java/com/damyo/alpha/api/smokingarea/service/SmokingAreaService.java
+++ b/src/main/java/com/damyo/alpha/api/smokingarea/service/SmokingAreaService.java
@@ -208,12 +208,9 @@ public class SmokingAreaService {
         }
 
         if (reportRequest.otherSuggestions() != null) {
-            SmokingArea smokingArea = smokingAreaRepository.findSmokingAreaById(smokingAreaId).orElseThrow(
-                    () -> new AreaException(NOT_FOUND_ID)
-            );
             SmokingAreaReportDetail smokingAreaReportDetail = SmokingAreaReportDetail.builder()
                             .otherSuggestion(reportRequest.otherSuggestions())
-                            .smokingArea(smokingArea)
+                            .smokingAreaId(smokingAreaId)
                             .build();
 
             smokingAreaReportDetailRepository.save(smokingAreaReportDetail);

--- a/src/main/java/com/damyo/alpha/api/smokingarea/service/SmokingAreaService.java
+++ b/src/main/java/com/damyo/alpha/api/smokingarea/service/SmokingAreaService.java
@@ -1,15 +1,17 @@
 package com.damyo.alpha.api.smokingarea.service;
 
 import com.damyo.alpha.api.smokingarea.controller.dto.*;
-import com.damyo.alpha.api.smokingarea.domain.SmokingArea;
-import com.damyo.alpha.api.smokingarea.domain.SmokingAreaRepository;
+import com.damyo.alpha.api.smokingarea.domain.*;
 import com.damyo.alpha.api.smokingarea.exception.AreaException;
+import com.damyo.alpha.api.user.controller.dto.ReportRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.SetOperations;
 import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
@@ -25,7 +27,13 @@ import static com.damyo.alpha.api.smokingarea.exception.AreaErrorCode.NOT_FOUND_
 public class SmokingAreaService {
 
     private final SmokingAreaRepository smokingAreaRepository;
+    private final SmokingAreaReportDetailRepository smokingAreaReportDetailRepository;
     private final RedisTemplate<String, Object> redisTemplate;
+    private static final String NOT_EXIST_KEY = "not-exist";
+    private static final String TAG_KEY = "incorrect-tag";
+    private static final String LOCATE_KEY = "incorrect-locate";
+    private static final String WORD_KEY = "inappropriate-word";
+    private static final String PICTURE_KEY = "inappropriate-picture";
 
     public List<SmokingAreaSummaryResponse> findAreaAll(){
         List<SmokingArea> areas = smokingAreaRepository.findAll();
@@ -156,26 +164,93 @@ public class SmokingAreaService {
         return areaResponseList;
     }
 
-    public void reportSmokingArea(String smokingAreaId, UUID userId) {
+    public void handleReport(String smokingAreaId, UUID userId, ReportRequest reportRequest) {
         SetOperations<String, Object> setOperations = redisTemplate.opsForSet();
-        String key = "SA::" + smokingAreaId;
-        if (Boolean.TRUE.equals(setOperations.isMember(key, userId))) {
+        String setKey = "report-users::" + smokingAreaId + "::set";
+        if (setOperations.isMember(setKey, userId)) {
             log.error("[Area]: area report already {}", smokingAreaId);
             throw new AreaException(ALREADY_REPORT);
         }
         log.info("[Area]: area report complete");
-        setOperations.add(key, userId);
-    }
+        setOperations.add(setKey, userId);
 
+        String hashKey = "smoking-area::" + smokingAreaId + "::hash";
+        HashOperations<String, String, Long> hashOperations = redisTemplate.opsForHash();
+        if (reportRequest.notExist()) {
+            hashOperations.increment(hashKey, NOT_EXIST_KEY, 1L);
+        }
+        else {
+            hashOperations.increment(hashKey, NOT_EXIST_KEY, 0L);
+        }
+        if (reportRequest.incorrectTag()) {
+            hashOperations.increment(hashKey, TAG_KEY, 1L);
+        }
+        else {
+            hashOperations.increment(hashKey, TAG_KEY, 0L);
+        }
+        if (reportRequest.incorrectLocation()) {
+            hashOperations.increment(hashKey, LOCATE_KEY, 1L);
+        }
+        else {
+            hashOperations.increment(hashKey, LOCATE_KEY, 0L);
+        }
+        if (reportRequest.inappropriateWord()) {
+            hashOperations.increment(hashKey, WORD_KEY, 1L);
+        }
+        else {
+            hashOperations.increment(hashKey, WORD_KEY, 0L);
+        }
+        if (reportRequest.inappropriatePicture()) {
+            hashOperations.increment(hashKey, PICTURE_KEY, 1L);
+        }
+        else {
+            hashOperations.increment(hashKey, PICTURE_KEY, 0L);
+        }
+
+        if (reportRequest.otherSuggestions() != null) {
+            SmokingArea smokingArea = smokingAreaRepository.findSmokingAreaById(smokingAreaId).orElseThrow(
+                    () -> new AreaException(NOT_FOUND_ID)
+            );
+            SmokingAreaReportDetail smokingAreaReportDetail = SmokingAreaReportDetail.builder()
+                            .otherSuggestion(reportRequest.otherSuggestions())
+                            .smokingArea(smokingArea)
+                            .build();
+
+            smokingAreaReportDetailRepository.save(smokingAreaReportDetail);
+        }
+    }
 
     @Scheduled(cron = "0 0 0 1 * ?", zone = "Asia/Seoul")
     public void updateSmokingAreaByReport() {
-        Set<String> keys = redisTemplate.keys("SA*");
+//        Set<String> keys = redisTemplate.keys("SA*");
+//        if (keys != null) {
+//            SetOperations<String, Object> setOperations = redisTemplate.opsForSet();
+//            for (String key : keys) {
+//                String smokingAreaId = key.split("::")[1];
+//                if (setOperations.size(key) >= 5) {
+//                    smokingAreaRepository.updateSmokingAreaActiveById(smokingAreaId);
+//                    redisTemplate.delete(key);
+//                }
+//            }
+//        }
+        Set<String> keys = redisTemplate.keys("smoking-area*");
         if (keys != null) {
-            SetOperations<String, Object> setOperations = redisTemplate.opsForSet();
+            HashOperations<String, String, Long> hashOperations = redisTemplate.opsForHash();
             for (String key : keys) {
                 String smokingAreaId = key.split("::")[1];
-                if (setOperations.size(key) >= 5) {
+                long notExist = Long.parseLong(String.valueOf(hashOperations.get(key, NOT_EXIST_KEY)));
+                long incorrectTag = Long.parseLong(String.valueOf(hashOperations.get(key, TAG_KEY)));
+                long incorrectLocate = Long.parseLong(String.valueOf(hashOperations.get(key, LOCATE_KEY)));
+                long inappropriateWord = Long.parseLong(String.valueOf(hashOperations.get(key, WORD_KEY)));
+                long inappropriatePicture = Long.parseLong(String.valueOf(hashOperations.get(key, PICTURE_KEY)));
+
+                smokingAreaRepository.updateNotExist(smokingAreaId, notExist);
+                smokingAreaRepository.updateIncorrectTag(smokingAreaId, incorrectTag);
+                smokingAreaRepository.updateIncorrectLocate(smokingAreaId, incorrectLocate);
+                smokingAreaRepository.updateInappropriateWord(smokingAreaId, inappropriateWord);
+                smokingAreaRepository.updateInappropriatePicture(smokingAreaId, inappropriatePicture);
+
+                if (notExist >= 5) {
                     smokingAreaRepository.updateSmokingAreaActiveById(smokingAreaId);
                     redisTemplate.delete(key);
                 }

--- a/src/main/java/com/damyo/alpha/api/user/controller/UserController.java
+++ b/src/main/java/com/damyo/alpha/api/user/controller/UserController.java
@@ -3,6 +3,7 @@ package com.damyo.alpha.api.user.controller;
 import com.damyo.alpha.api.auth.domain.UserDetailsImpl;
 import com.damyo.alpha.api.picture.service.S3ImageService;
 import com.damyo.alpha.api.smokingarea.service.SmokingAreaService;
+import com.damyo.alpha.api.user.controller.dto.ReportRequest;
 import com.damyo.alpha.api.user.controller.dto.UserResponse;
 import com.damyo.alpha.api.user.domain.User;
 import com.damyo.alpha.api.user.domain.UserRepository;
@@ -112,15 +113,16 @@ public class UserController {
         return ResponseEntity.ok().body("회원 삭제 완료");
     }
 
-    @GetMapping("/report/{smokingAreaId}")
+    @PostMapping("/report/{smokingAreaId}")
     @Operation(summary = "흡연구역 신고", description = "흡연구역이 존재하지 않을 때 유저가 보내는 요청")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "흡연구역 신고 성공"),
             @ApiResponse(responseCode = "R101", description = "이미 신고한 흡연구역을 다시 신고한 경우")
     })
-    public ResponseEntity<?> reportSmokingArea(@PathVariable String smokingAreaId, @AuthenticationPrincipal UserDetailsImpl details) {
+    public ResponseEntity<?> reportSmokingArea(@PathVariable String smokingAreaId, @AuthenticationPrincipal UserDetailsImpl details,
+                                               @RequestBody ReportRequest reportRequest) {
         log.info("[User]: /report/{}", smokingAreaId);
-        smokingAreaService.reportSmokingArea(smokingAreaId, details.getId());
+        smokingAreaService.handleReport(smokingAreaId, details.getId(), reportRequest);
         return ResponseEntity.ok().body("신고 완료");
     }
 }

--- a/src/main/java/com/damyo/alpha/api/user/controller/dto/ReportRequest.java
+++ b/src/main/java/com/damyo/alpha/api/user/controller/dto/ReportRequest.java
@@ -1,0 +1,12 @@
+package com.damyo.alpha.api.user.controller.dto;
+
+public record ReportRequest(
+        Boolean notExist,
+        Boolean incorrectTag,
+        Boolean incorrectLocation,
+        Boolean inappropriateWord,
+        Boolean inappropriatePicture,
+        String otherSuggestions
+
+) {
+}


### PR DESCRIPTION
## Overview
지난 회의때 변경하기로한 정보 수정 제안 적용

## Task Details
- SmokingArea테이블에 5개 항목 컬럼 추가
- 기존 레디스에서 중복신고 체크와 동시에 존재하지 않음을 처리했는데 이것을 중복체크용으로 그대로 사용함.
- (H: 흡연구역ID, HK: 정보 수정 제안 5개의 항목, V: 각 항목의 합)으로 하는 레디스 해시 자료구조를 사용하여 항목들 관리
- 일정 주기마다 레디스의 5개 항목을 테이블 컬럼에 쓰고, HK: not-exist의 값이 일정 수치 이상이면 해당 흡연구역 비활성화
- 기타 제안사항은 새로운 테이블을 만들어 흡연구역ID와 함께 저장